### PR TITLE
Propose simplified structure for binding.

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -3,10 +3,15 @@
   "reason": {
     "react-jsx": 3
   },
-  "sources": {
+  "sources": [{
     "dir" : "src",
     "subdirs" : true
   },
+  {
+    "dir" : "example",
+    "subdirs" : true,
+    "type": "dev"
+  }],
   "bsc-flags": ["-bs-super-errors", "-bs-no-version-header"],
   "package-specs": [{
     "module": "commonjs",

--- a/example/Simple.re
+++ b/example/Simple.re
@@ -1,15 +1,18 @@
-open DivertiseasiaBsServiceWorker;
-if (ServiceWorker.isSupported()) {
-  ServiceWorker.windowAddEventListener("load", () => {
-    Js.Promise.(ServiceWorker.register("demo-sw.js")
-      |> then_((b:ServiceWorker.ServiceWorkerRegistration.t) => {
-        Js.log2("[App] ServiceWorker registration success: ", b#scope);
-        resolve(Some(b));
-      })
-      |> catch(e => {
-        Js.log2("[App] ServiceWorker registration failed (expected): ", e);
-        resolve(None)
-      })
-    ) |> ignore;
-  })
+switch(ServiceWorker.maybeServiceWorker){
+| None => Js.log("[App] No ServiceWorker")
+| Some(worker) =>{
+    open ServiceWorker;
+    Window.addEventListener("load", () => {
+      Js.Promise.(worker->register("demo-sw.js")
+        |> then_((b:ServiceWorker.Registration.t) => {
+          Js.log2("[App] ServiceWorker registration success: ", b##scope);
+          resolve(Some(b));
+        })
+        |> catch(e => {
+          Js.log2("[App] ServiceWorker registration failed (expected): ", e);
+          resolve(None)
+        })
+      ) |> ignore;
+    })
+  }
 }

--- a/src/ServiceWorker.re
+++ b/src/ServiceWorker.re
@@ -2,10 +2,11 @@ type t = Js.t({.
   scriptURL: string,
   state: string,
 });
+type _serviceWorker = t;
 
 module Container {
   type t = Js.t({.
-    controller: option(t)
+    controller: Js.Nullable.t(_serviceWorker)
   });
 }
 
@@ -14,6 +15,7 @@ module Registration {
     .
     scope: string,
     updateViaCache: string,
+    active: Js.Nullable.t(_serviceWorker),
     [@bs.meth] unregister: unit => Js.Promise.t(bool),
   });
 }

--- a/src/ServiceWorker.re
+++ b/src/ServiceWorker.re
@@ -14,7 +14,7 @@ module Registration {
     .
     scope: string,
     updateViaCache: string,
-    unregister: unit => Js.Promise.t(bool),
+    [@bs.meth] unregister: unit => Js.Promise.t(bool),
   });
 }
 

--- a/src/ServiceWorker.re
+++ b/src/ServiceWorker.re
@@ -1,61 +1,44 @@
-type serviceWorker = {
+type t = Js.t({.
   scriptURL: string,
   state: string,
-};
+});
 
-type serviceWorkerContainer = {
-  controller: option(serviceWorker)
-};
+module Container {
+  type t = Js.t({.
+    controller: option(t)
+  });
+}
 
 module Registration {
   type t = Js.t({
     .
     scope: string,
     updateViaCache: string,
-    worker: option(serviceWorker),
     unregister: unit => Js.Promise.t(bool),
   });
 }
 
-module Navigator {
-  type t = {
-    serviceWorker:option(serviceWorkerContainer),
-  };
-  [@bs.val] external navigator: t = "navigator";
-  let _supportsServiceWorker = ():bool => {
-    switch(navigator.serviceWorker) {
-      | Some(_) => true;
-      | None => false
-    }
-  }
-}
-
 module Window {
   type t;
-  [@bs.send]
-  external addEventListener : (t, string, unit => 'a) => unit =
-    "addEventListener";
-  [@bs.val] external window: t = "window";
+  [@bs.scope "window"][@bs.val] external addEventListener : (string, unit => 'a) => unit = "addEventListener";
 };
 
-[@bs.val] external registerJs: (string) => Js.Promise.t(Registration.t) = "navigator.serviceWorker.register";
-[@bs.val] external _controller: Js.Nullable.t(serviceWorker) = "navigator.serviceWorker.controller"
+[@bs.scope "navigator"] [@bs.val] external maybeServiceWorker: option(Container.t) = "serviceWorker";
+[@bs.send] external register: (Container.t, string) => Js.Promise.t(Registration.t) = "register";
 
-exception RegistrationException(Js.Promise.error);
-let register = (filename:string):Js.Promise.t(Registration.t) => {
-  Js.Promise.(
-    registerJs(filename)
-    |> then_((b:Registration.t) => {
-      resolve(b);
-    })
-    |> catch(e => {
-      reject(RegistrationException(e))
-    })
-  )
-};
-let isSupported = Navigator._supportsServiceWorker;
-let getController = () => Js.Nullable.toOption(_controller);
+/*
+// To check
+switch(ServiceWorker.maybeServiceWorker){
+| None => Js.log("[App] No ServiceWorker");
+| Some(workerContainer) => Js.log2("Yes, there is a", worker##controller);
+}
 
-let windowAddEventListener = (eventName:string, func):unit => {
-  Window.addEventListener(Window.window, eventName, func);
-};
+// To register
+workerContainer->register("filename")
+|> ... Handle promise ...
+
+// To work with Registration.t
+let handlerRegistartion = register => {
+  Js.log2("[App] ServiceWorker registration success: ", register##scope);
+}
+*/


### PR DESCRIPTION
- Remove `Navigation` module and bind directly to navigation scope
- Remove `windowAddEventListener` and bind directly to `window` scope
- Remove `isSupported` binding and use the object present & pattern matching.
- Remove `registerJs` and its conversion, bind directly to `Js.t` in Registration.t
- Rename `serviceWorker` type to `t` as convention type naming.
- Change `serviceWorkerContainer` to module `Container`
- Remove `_getController` and use direct access `##` from `Container.t`